### PR TITLE
Allow the program to use full access to the computer

### DIFF
--- a/docs/code-execution/usage.mdx
+++ b/docs/code-execution/usage.mdx
@@ -22,6 +22,18 @@ interpreter.custom_instructions = "Replicate has already been imported."
 interpreter.chat("Please generate an image on replicate...") # Interpreter will be logged into Replicate
 ```
 
+# Enabling Full Access
+
+To enable full access to the computer, allowing the program to use the computer autonomously, you can use the `grant_full_access` method:
+
+```python
+from interpreter import interpreter
+
+interpreter.computer.grant_full_access()
+```
+
+This will allow the program to use full access to the computer autonomously to accomplish tasks.
+
 # Custom Languages
 
 You also have control over the `computer`'s languages (like Python, Javascript, and Shell), and can easily append custom languages:

--- a/interpreter/core/computer/computer.py
+++ b/interpreter/core/computer/computer.py
@@ -141,3 +141,12 @@ Do not import the computer module, or any of its sub-modules. They are already i
         for key, value in data_dict.items():
             if hasattr(self, key):
                 setattr(self, key, value)
+
+    def grant_full_access(self):
+        """
+        Grants full access to the computer, allowing the program to use the computer autonomously.
+        """
+        self.import_computer_api = True
+        self.import_skills = True
+        self.verbose = True
+        self.debug = True

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -135,6 +135,9 @@ class OpenInterpreter:
         self.empty_code_output_template = empty_code_output_template
         self.code_output_sender = code_output_sender
 
+        # Grant full access to the computer
+        self.computer.grant_full_access()
+
     def local_setup(self):
         """
         Opens a wizard that lets terminal users pick a local model.


### PR DESCRIPTION
Add a method to grant full access to the computer and update initialization to call this method.

* **Computer Class**:
  - Add `grant_full_access` method to the `Computer` class in `interpreter/core/computer/computer.py`.
  - The method sets `import_computer_api`, `import_skills`, `verbose`, and `debug` attributes to `True`.

* **OpenInterpreter Class**:
  - Update the `OpenInterpreter` class in `interpreter/core/core.py` to call `grant_full_access` during initialization.

* **Documentation**:
  - Update `docs/code-execution/usage.mdx` to include instructions on how to enable and use the full access feature.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Thetruemank/open-interpreter?shareId=7151b3b0-db49-4da8-bc84-bf7d3e10a5c7).